### PR TITLE
Add "WHERE IN" to conditions with array as value

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -1363,7 +1363,7 @@ class Model extends \CI_Model implements \ArrayAccess
                 /* Associated Array */
                 foreach ($condition as $field => $value) {
                     
-                    $query->where($field, $value);
+                    (is_array($value)) ? $query->where_in($field, $value) : $query->where($field, $value);
                 }
             }
         } 


### PR DESCRIPTION
I have added a functionality where when using Find/FindAll etc with an array in the value of conditions the library will use where_in().
For example:
```
$mUsers = $users->findAll(['name'=>['Mark', 'Mac', 'Mike']]); 
```