### PR TITLE
Fix NULL valued `model` variable bug

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -1180,7 +1180,7 @@ class Model extends \CI_Model implements \ArrayAccess
         } else {
             // Original CodeIgniter 3 model loader
             get_instance()->load->model($modelName);
-            $model = $this->$modelName;
+            $model = get_instance()->$modelName;
         }
 
         $libClass = __CLASS__;
@@ -1560,7 +1560,7 @@ class Model extends \CI_Model implements \ArrayAccess
             } else {
                 // Original CodeIgniter 3 model loader
                 get_instance()->load->model($modelName);
-                $model = $this->$modelName;
+                $model = get_instance()->$modelName;
             }
 
             // Check return type


### PR DESCRIPTION
Hey, I found a small but **critical** bug that essentially disables the "Relationships" feature when I'm trying to use Active Record with original CI 3 model loader.

This is caused by bad variable creation after successfully loaded the model. The new variable `$model` refers to `$this->$modelName`, which value is `NULL` instead of referencing the freshly loaded model Singleton from CI Instance through `get_instance()->$modelName`.

`$model = NULL` obviously could trigger several misleading Exception, one of them being:
``throw new Exception("Model `{$modelName}` does not extend {$libClass}", 500);`` from line 1192

The error confused me for an hour because I'm 100% sure that I have extended my model properly.

Hope this helps, **cheers**!