### PR TITLE
Add postgress sequence name to fix inserted id

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -688,9 +688,13 @@ class Model extends \CI_Model implements \ArrayAccess
      */
     public function getLastInsertID()
     {
-        // Only pdo drivers with postgres accepts a sequence name parameter.
         if ($this->_postgresSeqName !== null) {
-            return $this->getDB()->insert_id($this->_postgresSeqName);
+            try{
+                return $this->getDB()->insert_id($this->_postgresSeqName);
+            }
+            catch(Exception $exp){
+                throw new \Exception('Only pdo drivers with postgres accepts a sequence name parameter for insert_id.', 500, $exp);
+            }
         }
 
         return $this->getDB()->insert_id();

--- a/src/Model.php
+++ b/src/Model.php
@@ -49,6 +49,15 @@ class Model extends \CI_Model implements \ArrayAccess
     protected $primaryKey = 'id';
 
     /**
+     *  Postgres uses sequences that are needed to retrieve last inserted ID.
+     *  This implementation only works with PDO drivers and postgres dbs.
+     *  Optional - leave blank to ignore
+     *
+     * @var string postgres specific sequence name
+     */
+    protected $_postgresSeqName = null;
+
+    /**
      * Indicates if the model should be timestamped.
      *
      * @var bool
@@ -679,6 +688,11 @@ class Model extends \CI_Model implements \ArrayAccess
      */
     public function getLastInsertID()
     {
+        // Only pdo drivers with postgres accepts a sequence name parameter.
+        if ($this->_postgresSeqName !== null) {
+            return $this->getDB()->insert_id($this->_postgresSeqName);
+        }
+
         return $this->getDB()->insert_id();
     }
 


### PR DESCRIPTION
When calling the PHP function insert_id with Postgres databases it supports a string parameter that specifies the sequence name.  I've added a small fix to support this function for Postgres.