### PR TITLE
Remove backticks from _field

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -1572,7 +1572,7 @@ class Model extends \CI_Model implements \ArrayAccess
      */
     protected function _field($columnName)
     {
-        return ($this->alias) ? "`{$this->alias}`.`{$columnName}`" : "`{$this->table}`.`{$columnName}`";
+        return ($this->alias) ? "{$this->alias}.{$columnName}" : "{$this->table}.{$columnName}";
     }
 
     /**


### PR DESCRIPTION
When using PHP sqlsrv (SQL Server), backticks will give the following error:
The multi-part identifier could not be bound.