### PR TITLE
Deleted verification of definition of softDeletedFalseValue.

### DIFF
--- a/src/Model.php
+++ b/src/Model.php
@@ -926,8 +926,7 @@ class Model extends \CI_Model implements \ArrayAccess
         $query = $this->withTrashed()->_findByCondition($condition);
 
         /* Soft Delete Mode */
-        if (static::SOFT_DELETED 
-            && isset($this->softDeletedFalseValue)) {
+        if (static::SOFT_DELETED) {
             
             // Mark the records as deleted
             $attributes[static::SOFT_DELETED] = $this->softDeletedFalseValue;
@@ -1538,7 +1537,7 @@ class Model extends \CI_Model implements \ArrayAccess
             // Reset SOFT_DELETED switch
             $this->_withoutSoftDeletedScope = false;
         } 
-        elseif (static::SOFT_DELETED && isset($this->softDeletedFalseValue)) {
+        elseif (static::SOFT_DELETED) {
             // Add condition
             $this->_dbr->where($this->_field(static::SOFT_DELETED), 
             $this->softDeletedFalseValue);


### PR DESCRIPTION
Deleted because that implementation don't allow softDeletedFalseValue to be NULL in the DB, and I
consider that is redundant: is defined by default and if you want to disable soft delete, just make
the constant SOFT_DELETED = FALSE.